### PR TITLE
fix: use :latest tag instead of :master in docs, add master tag to CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -56,6 +56,7 @@ jobs:
             type=semver,pattern={{major}}
             type=sha,format=short
             type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=master,enable={{is_default_branch}}
 
       - name: Build and push Docker image
         id: push

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to mikrus-mcp.
 
+## [1.1.1] — 2026-05-22
+
+### Fixed
+
+- Docker `:master` tag stuck at v0.1.0 — CI (`publish.yml`) now pushes both `:latest` and `:master` tags on default branch builds
+- README: all 6 docker run and Claude Desktop config examples updated from `:master` to `:latest` to reference the canonical working tag
+
 ## [1.1.0] — 2026-05-17
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Pulls the published image from GitHub Container Registry:
 ```bash
 docker run --rm \
   --env-file .env \
-  ghcr.io/paulomac1000/mikrus-mcp:master
+  ghcr.io/paulomac1000/mikrus-mcp:latest
 ```
 
 Or pass credentials directly:
@@ -86,7 +86,7 @@ Or pass credentials directly:
 docker run --rm \
   -e MIKRUS_API_KEY=your_key \
   -e MIKRUS_SERVER_NAME=your_server \
-  ghcr.io/paulomac1000/mikrus-mcp:master
+  ghcr.io/paulomac1000/mikrus-mcp:latest
 ```
 
 #### Local build (use when modifying the code or for development)
@@ -114,7 +114,7 @@ The server communicates over `stdio` by default. Set `MCP_PORT` to enable SSE tr
 > docker run --rm \
 >   --env-file .env \
 >   -v ~/.ssh/id_ed25519:/home/appuser/.ssh/id_ed25519:ro \
->   ghcr.io/paulomac1000/mikrus-mcp:master
+>   ghcr.io/paulomac1000/mikrus-mcp:latest
 > ```
 > SSH keys must have permissions `600` or `400` and be readable by the `appuser` user inside the container (UID 1000). If your host user has a different UID, adjust ownership with `chown 1000:1000 ~/.ssh/id_ed25519` or use a less restrictive mode. Certificates can be mounted the same way.
 
@@ -305,7 +305,7 @@ Add the following to your `claude_desktop_config.json`. Use absolute paths — C
         "--rm",
         "--env-file",
         "/absolute/path/to/mikrus-mcp/.env",
-        "ghcr.io/paulomac1000/mikrus-mcp:master"
+        "ghcr.io/paulomac1000/mikrus-mcp:latest"
       ]
     }
   }
@@ -324,7 +324,7 @@ Add the following to your `claude_desktop_config.json`. Use absolute paths — C
         "--rm",
         "-e", "MIKRUS_API_KEY=your_key",
         "-e", "MIKRUS_SERVER_NAME=your_server",
-        "ghcr.io/paulomac1000/mikrus-mcp:master"
+        "ghcr.io/paulomac1000/mikrus-mcp:latest"
       ]
     }
   }
@@ -360,7 +360,7 @@ Add the following to your `claude_desktop_config.json`. Use absolute paths — C
         "-v", "/home/user/.ssh/id_ed25519:/home/appuser/.ssh/id_ed25519:ro",
         "-e", "MCP_SERVERS={\"prod\":{\"type\":\"ssh\",\"host\":\"10.0.0.5\",\"user\":\"admin\",\"ssh_key\":\"/home/appuser/.ssh/id_ed25519\"}}",
         "-e", "MCP_DEFAULT_SERVER=prod",
-        "ghcr.io/paulomac1000/mikrus-mcp:master"
+        "ghcr.io/paulomac1000/mikrus-mcp:latest"
       ]
     }
   }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mikrus-mcp"
-version = "1.1.0"
+version = "1.1.1"
 description = "MCP server for mikr.us API"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/mikrus_mcp/__init__.py
+++ b/src/mikrus_mcp/__init__.py
@@ -1,3 +1,3 @@
 """Mikr.us MCP Server package."""
 
-__version__ = "1.1.0"
+__version__ = "1.1.1"

--- a/src/mikrus_mcp/tools/constants.py
+++ b/src/mikrus_mcp/tools/constants.py
@@ -51,7 +51,7 @@ READ_ONLY_SERVICE_ACTIONS: Final = frozenset({"status", "is-active", "is-enabled
 PROCESS_ACTIONS: Final = frozenset({"list", "kill"})
 
 # Tool version — injected into every response _meta envelope
-TOOLS_VERSION: Final = "1.1.0"
+TOOLS_VERSION: Final = "1.1.1"
 
 # Capability metadata schema version (describe_mikrus_capabilities)
 CAPABILITIES_SCHEMA_VERSION: Final = "1.0.0"


### PR DESCRIPTION
## Problem

The docker-compose and README referenced `ghcr.io/paulomac1000/mikrus-mcp:master` but CI only builds the `:latest` tag (and semver/SHA tags). The `:master` tag was a stale v0.1.0 image that lacked the REST bridge, modern tools, and had a broken healthcheck.

## Changes

- **README.md**: Replace all 6 occurrences of `:master` → `:latest` in docker run examples and Claude Desktop config examples
- **publish.yml**: Add `type=raw,value=master,enable={{is_default_branch}}` so CI also pushes an up-to-date `:master` tag for backward compatibility